### PR TITLE
finish homework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache/
 build/
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,9 @@ set(CMAKE_CXX_STANDARD 17)
 project(main LANGUAGES CXX)
 
 add_executable(main main.cpp)
+
+add_custom_command(
+    TARGET main POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_SOURCE_DIR}/test.json
+            $<TARGET_FILE_DIR:main>/test.json)

--- a/main.cpp
+++ b/main.cpp
@@ -323,7 +323,7 @@ std::string dumper(JSONObject const& obj){
         dovisit(dovisit,obj);
     } else{
         //pretty version
-        int deepth = 0;
+        int depth = 0;
         auto dovisit =[&](auto &&func,JSONObject const& obj) -> void{
         std::visit(
             overloaded{
@@ -340,19 +340,19 @@ std::string dumper(JSONObject const& obj){
                     res += "{\n";
                     for(auto [key,value]:val){
                         res += "\t";
-                        for(int i = 0; i < deepth; i++)
+                        for(int i = 0; i < depth; i++)
                             res += "\t";
                         res += key;
                         res += " : ";
-                        deepth++;
+                        depth++;
                         func(func,value);
-                        deepth--;
+                        depth--;
                         res += ",";
                         res += "\n";
                     }
                     res = res.substr(0,res.size() - 2);
                     res += "\n";
-                    for(int i = 0; i < deepth; i++)
+                    for(int i = 0; i < depth; i++)
                         res += "\t";
                     res += "}";
                 },

--- a/test.json
+++ b/test.json
@@ -1,0 +1,4 @@
+{
+    Hello:[true,false,123,null,"\x44oge"],
+    "World":{"jiumao":233}
+}


### PR DESCRIPTION
# 实验报告
## homework部分
1. 在parse函数部分新增了三个分支，首先去判断一下首字母是否符合要求，如果符合的话就解析为true，false，null
2. 这里我把解析字符串单独写成了一个函数：try_parse_string，并通过一个形参queto来决定应该按照单引号来解析还是按照双引号来解析
3. 在解析字符串的时候增加了两个状态Hex1，Hex2，定义一个变量hex_ch，在Hex1中，加上对应的十六进制值，在Hex2中先乘上16，再加上对应十六进制值，最后把该字符加到结果上并把该字符清零。如果匹配失败，会自动退出到Raw状态

## challenge部分
challenge部分我完成了4，5，6

4. 实现在dumper函数中。dump的时候使用了小彭老师课上讲的std::visit以及魔法overloaded。依次把结果加到res上去就可以了。在处理字典和数组的时候递归去做就可以了。
5. 这里我遇到的问题是如果字典里面套了一个字典，就需要考虑每行打印\t的个数，这里我的解决方法是新增一个depth变量，记录递归的深度，然后按照递归深度打印\t。dumper函数有一个模板参数is_pretty来表示是否用pretty的方式来dump
6. 我的解决方法是利用正则表达式，表达式如下：
```
[ \n\r\t\v\f\0]*?[\'\"]{0,1}[a-zA-Z]+[\'\"]{0,1}[ \n\r\t\v\f\0]*?: 
```
最后匹配出来后要将空格都去除。

## 遇到的问题
在解析字典的时候，如果键或者值后面有空格的话就会解析失败，所以要把这些空格也给考虑进去。

此外，我还增加了read_file这个函数，能够从文件中读取字符串，并且在CMakeLists中将test.json复制到对应文件夹下

## 对print.h的思考
print.h中使用了SFINAE的技巧来实现类似与c++20中require的功能。我通过查阅cppreference中的std::void_t中学会了这个技巧

```cpp
// primary template handles types that do not support pre-increment:
template< class, class = void >
struct has_pre_increment_member : std::false_type { };
 
// specialization recognizes types that do support pre-increment:
template< class T >
struct has_pre_increment_member<T,
           std::void_t<decltype( ++std::declval<T&>() )>
       > : std::true_type { };
```
在所以说为一个类添加do_print方法后就可以支持用print函数打印了。但是print.h中还有不少魔法我没有看明白，期待小彭老师的讲解。

最后的最后，十分感谢小彭老师给我们带来这么好的一份教程，我在里面学到了不少东西。