### PR TITLE
增加列表和键值对中的空白检查

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -125,6 +125,8 @@ std::pair<JSONObject, size_t> parse(std::string_view json) {
             }
             res.push_back(std::move(obj));
             i += eaten;
+            //在一个数据插入后检查后面的空白，并吃掉
+            while(i < json.size() && std::isspace(static_cast<unsigned char>(json[i]))) ++i;
             if (json[i] == ',') {
                 i += 1;
             }
@@ -159,6 +161,10 @@ std::pair<JSONObject, size_t> parse(std::string_view json) {
             }
             i += valeaten;
             res.try_emplace(std::move(key), std::move(valobj));
+
+            //在一个数据插入后检查后面的空白，并吃掉
+            while(i < json.size() && std::isspace(static_cast<unsigned char>(json[i]))) ++i;
+
             if (json[i] == ',') {
                 i += 1;
             }
@@ -177,7 +183,13 @@ template <class ...Fs>
 overloaded(Fs...) -> overloaded<Fs...>;
 
 int main() {
-    std::string_view str = R"JSON(985.211)JSON";
+    std::string_view str = R"JSON([[1,2
+    ],"aa"])JSON";
+    std::string_view str2 = R"JSON({"aaa":
+                                        {
+                                         "bbb":1
+                                        },
+                                        "ccc":2})JSON";
     auto [obj, eaten] = parse(str);
     print(obj);
     std::visit(


### PR DESCRIPTION
在列表和键值对的解析中
<img width="852" height="248" alt="屏幕截图 2025-12-20 122338" src="https://github.com/user-attachments/assets/5e6f1158-faef-4af6-bc38-46ed602b2843" />
像如上这样的列表和键值对会被错误解析如下：
<img width="340" height="41" alt="屏幕截图 2025-12-20 122917" src="https://github.com/user-attachments/assets/650e0648-dd90-4a33-b69c-fb526e11ee2a" />
<img width="273" height="42" alt="屏幕截图 2025-12-20 122931" src="https://github.com/user-attachments/assets/22b66dae-7844-4dc2-81cb-58b1098d8628" />
原因是在每一个元素被插入到列表或键值对中的时候，没有检查后面有无空白，导致循环会再执行一次，并且在递归中不会匹配到任何类型，导致返回{JSONObject{std::nullptr_t{}}, 0}，在列表中会直接在后面插入null，在键值对中则会导致key不是std::string类型而导致错误退出，后面的元素都被忽略。